### PR TITLE
The tests involving Date assume Pacific Time.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "pretest": "mkdir -p build && d3-bundler --polyfill-map --format=umd --name=scale -- index.js > build/scale.js",
-    "test": "faucet `find test -name '*-test.js'`",
+    "test": "TZ=America/Los_Angeles faucet `find test -name '*-test.js'`",
     "prepublish": "npm run test && uglifyjs build/scale.js -c -m -o build/scale.min.js && rm -f build/scale.zip && zip -j build/scale.zip -- LICENSE README.md build/scale.js build/scale.min.js"
   },
   "devDependencies": {


### PR DESCRIPTION
Some of the tests will fail for users that run them with other time zones set by default.  This fix ensures the tests are run in the PT time zone.

The failing tests:

```
⨯ linear.domain(domain) coerces domain values to numbers
  not ok 238 should be equivalent
    ---
      operator: deepEqual
      expected: [ 631180800000, 662716800000 ]
      actual:   [ 631152000000, 662688000000 ]
      at: Test.<anonymous> (/Users/jason/src/d3-scale/test/linear-test.js:102:8)
    ...
⨯ pow.domain(domain) coerces domain values to numbers
  not ok 649 should be equivalent
    ---
      operator: deepEqual
      expected: [ 631180800000, 662716800000 ]
      actual:   [ 631152000000, 662688000000 ]
      at: Test.<anonymous> (/Users/jason/src/d3-scale/test/pow-test.js:138:8)
    ...
```