### PR TITLE
update deps that formerly used Map

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
   "devDependencies": {
     "d3-arrays": "~0.0.4",
     "d3-bundler": "~0.2.5",
-    "d3-color": "~0.2.1",
-    "d3-format": "~0.2.1",
-    "d3-interpolate": "~0.1.1",
+    "d3-color": "~0.2.5",
+    "d3-format": "~0.3.3",
+    "d3-interpolate": "^0.1.1",
     "d3-time": "~0.0.2",
-    "d3-time-format": "~0.0.1",
+    "d3-time-format": "~0.1.2",
     "faucet": "0.0",
     "tape": "4",
     "uglify-js": "2"


### PR DESCRIPTION
`Map` is still showing up in the built versions of this lib because it relies on older versions of other d3 modules that used `Map` until recently.  I noticed the same thing in d3-interpolate, so the version on that might need an additional bump.

Thanks!