### PR TITLE
switch to standard ES6 default imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ import identity from "./src/identity";
 import linear from "./src/linear";
 import log from "./src/log";
 import ordinal from "./src/ordinal";
-import {default as pow, sqrt} from "./src/pow";
+import pow, {sqrt} from "./src/pow";
 import quantile from "./src/quantile";
 import quantize from "./src/quantize";
 import rainbow from "./src/rainbow";

--- a/src/linear.js
+++ b/src/linear.js
@@ -2,7 +2,7 @@ import {bisect} from "d3-arrays";
 import {interpolate, interpolateNumber, interpolateRound} from "d3-interpolate";
 import nice from "./nice";
 import tickFormat from "./tickFormat";
-import {default as ticks, tickRange} from "./ticks";
+import ticks, {tickRange} from "./ticks";
 
 function uninterpolateClamp(a, b) {
   b = (b -= a = +a) || 1 / b;

--- a/src/log.js
+++ b/src/log.js
@@ -1,6 +1,6 @@
 import {range} from "d3-arrays";
 import {format} from "d3-format";
-import {default as linear, rebind} from "./linear";
+import linear, {rebind} from "./linear";
 import nice from "./nice";
 
 var tickFormat10 = format(".0e"),

--- a/src/pow.js
+++ b/src/pow.js
@@ -1,7 +1,7 @@
-import {default as linear, rebind} from "./linear";
+import linear, {rebind} from "./linear";
 import nice from "./nice";
 import tickFormat from "./tickFormat";
-import {default as ticks, tickRange} from "./ticks";
+import ticks, {tickRange} from "./ticks";
 
 function newPow(linear, exponent, domain) {
 

--- a/src/time.js
+++ b/src/time.js
@@ -1,5 +1,5 @@
 import {bisector, range} from "d3-arrays";
-import {default as linear, rebind} from "./linear";
+import linear, {rebind} from "./linear";
 import {format} from "d3-time-format";
 import {second, minute, hour, day, month, week, year} from "d3-time";
 import {tickRange} from "./ticks";

--- a/src/utcTime.js
+++ b/src/utcTime.js
@@ -1,4 +1,4 @@
-import {default as linear} from "./linear";
+import linear from "./linear";
 import {millisecond, newTime} from "./time";
 import {range} from "d3-arrays";
 import {utcFormat} from "d3-time-format";


### PR DESCRIPTION
Default exports of ES6 modules can be imported with a terser syntax: `import x from 'y'` rather than `import {default as x} from 'y'` (see [the spec](http://www.ecma-international.org/ecma-262/6.0/#sec-imports)).