### PR TITLE
move d3 devDependencies to dependencies and switch from d3-bundler to rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,19 +20,21 @@
     "url": "https://github.com/d3/d3-scale.git"
   },
   "scripts": {
-    "pretest": "mkdir -p build && d3-bundler --format=umd --name=scale -- index.js > build/scale.js",
+    "pretest": "mkdir -p build && rollup --format=cjs -- index.js > build/scale.js",
     "test": "TZ=America/Los_Angeles faucet `find test -name '*-test.js'`",
     "prepublish": "npm run test && uglifyjs build/scale.js -c -m -o build/scale.min.js && rm -f build/scale.zip && zip -j build/scale.zip -- LICENSE README.md build/scale.js build/scale.min.js"
   },
-  "devDependencies": {
+  "dependencies": {
     "d3-arrays": "~0.1.1",
-    "d3-bundler": "~0.2.5",
     "d3-color": "~0.2.6",
     "d3-format": "~0.3.3",
-    "d3-interpolate": "~0.1.1",
+    "d3-interpolate": "~0.1.2",
     "d3-time": "~0.0.5",
-    "d3-time-format": "~0.1.2",
+    "d3-time-format": "~0.1.3"
+  },
+  "devDependencies": {
     "faucet": "0.0",
+    "rollup": "0.20.3",
     "tape": "4",
     "uglify-js": "2"
   }


### PR DESCRIPTION
Here's a PR for the approach I discussed [here](https://github.com/d3/d3-scale/issues/3#issuecomment-152097728).

**TL;DR:** Using d3 modules with vanilla `npm` and `webpack` can be made more efficient/elegant without interfering with the `d3-bundler` and `Rollup` ES6 approaches.

As far as I can tell from discussion in #3, the only downside of moving d3 modules to "dependencies" was the problem of duplication. `npm@3` (packaged with the current stable version of `node`) completely solves this problem. (If `d3-A` requires `d3-B` and `d3-C`, and `d3-B` requires `d3-C`, `d3-C` is **not** duplicated.) Even for those still using `npm@2`, bundlers like `webpack` also solve this problem with [code de-duplication](https://webpack.github.io/docs/optimization.html#deduplication).

It has become standard practice for modular libraries to require other modules as dependencies in their npm builds (see [lodash](https://github.com/lodash/lodash/blob/npm/collection/invoke.js#L1) and [React](https://www.npmjs.com/package/react) -- two of the most popular npm packages). Publishing the `d3-X` builds on npm with their dependencies pre-injected is a huge pain. If I want to use `d3-A` and `d3-B` which both depend on `d3-C`, my current options are:

1. Require `d3-A` and `d3-B` as dependencies and get `d3-C` twice. This is obviously bad. `d3-C` can't even be de-duped by bundlers because it's already been injected into each module separately.
2. Use `d3-bundler` to create a custom build exporting `d3-A` and `d3-B`. This isn't very elegant: I need to add a custom tool to my build pipeline, manually track/update it every time I require some new `d3-X`, etc., which is precisely the problem that `npm` was designed to solve.
3. Use a bundler which understands the "jsnext:main" `package.json` field (bypassing the compiled build completely, straight into ES6 land). This is great, but only available if you're using Rollup. (Also, that field is in [a lot of flux](https://github.com/jsforum/jsforum/issues/5).)

Option 3 should, of course, stay available. This PR just replaces Option 1 with a strictly superior Option 4: require `d3-A` and `d3-B` as dependencies and get `d3-C` just once (bonus: still in a modular format for easier debugging).

@mbostock Thoughts? I'm happy to follow through with similar PRs on the other modules if you're interested.

(By the way, I think it makes sense to continue to put compiled UMD (dependency-injected) builds generated using `d3-bundler` on places like the d3 website for people to use without `npm`.)