### PR TITLE
Fix #13 - more control over implicit domain extension.

### DIFF
--- a/src/ordinal.js
+++ b/src/ordinal.js
@@ -1,20 +1,24 @@
 import {map} from "d3-arrays";
 
+var slice = [].slice,
+    recycle = {};
+
 function steps(length, start, step) {
   var steps = new Array(length), i = -1;
   while (++i < length) steps[i] = start + step * i;
   return steps;
 }
 
-function newOrdinal(domain, ranger) {
+function newOrdinal(domain, rangeMethod, rangeArguments) {
   var index,
       range,
-      rangeBand;
+      rangeBand,
+      rangeMissing;
 
   function scale(x) {
     var k = x + "", i = index.get(k);
     if (!i) {
-      if (ranger.t !== "range") return;
+      if (rangeMissing !== recycle) return rangeMissing;
       index.set(k, i = domain.push(x));
     }
     return range[(i - 1) % range.length];
@@ -26,14 +30,14 @@ function newOrdinal(domain, ranger) {
     index = map();
     var i = -1, n = x.length, xi, xk;
     while (++i < n) if (!index.has(xk = (xi = x[i]) + "")) index.set(xk, domain.push(xi));
-    return scale[ranger.t].apply(scale, ranger.a);
+    return scale[rangeMethod].apply(scale, rangeArguments);
   };
 
-  scale.range = function(x) {
+  scale.range = function(x, missing) {
     if (!arguments.length) return range.slice();
-    range = x.slice();
     rangeBand = 0;
-    ranger = {t: "range", a: arguments};
+    rangeMethod = "range";
+    rangeArguments = [range = x.slice(), rangeMissing = arguments.length < 2 ? recycle : missing];
     return scale;
   };
 
@@ -44,7 +48,9 @@ function newOrdinal(domain, ranger) {
         step = domain.length < 2 ? (start = (start + stop) / 2, 0) : (stop - start) / (domain.length - 1 + padding);
     range = steps(domain.length, start + step * padding / 2, step);
     rangeBand = 0;
-    ranger = {t: "rangePoints", a: arguments};
+    rangeMethod = "rangePoints";
+    rangeArguments = [[start, stop], padding];
+    rangeMissing = undefined;
     return scale;
   };
 
@@ -55,7 +61,9 @@ function newOrdinal(domain, ranger) {
         step = domain.length < 2 ? (start = stop = Math.round((start + stop) / 2), 0) : (stop - start) / (domain.length - 1 + padding) | 0; // bitwise floor for symmetry
     range = steps(domain.length, start + Math.round(step * padding / 2 + (stop - start - (domain.length - 1 + padding) * step) / 2), step);
     rangeBand = 0;
-    ranger = {t: "rangeRoundPoints", a: arguments};
+    rangeMethod = "rangeRoundPoints";
+    rangeArguments = [[start, stop], padding];
+    rangeMissing = undefined;
     return scale;
   };
 
@@ -69,7 +77,9 @@ function newOrdinal(domain, ranger) {
     range = steps(domain.length, start + step * outerPadding, step);
     if (reverse) range.reverse();
     rangeBand = step * (1 - padding);
-    ranger = {t: "rangeBands", a: arguments};
+    rangeMethod = "rangeBands";
+    rangeArguments = [[start, stop], padding, outerPadding];
+    rangeMissing = undefined;
     return scale;
   };
 
@@ -83,7 +93,9 @@ function newOrdinal(domain, ranger) {
     range = steps(domain.length, start + Math.round((stop - start - (domain.length - padding) * step) / 2), step);
     if (reverse) range.reverse();
     rangeBand = Math.round(step * (1 - padding));
-    ranger = {t: "rangeRoundBands", a: arguments};
+    rangeMethod = "rangeRoundBands";
+    rangeArguments = [[start, stop], padding, outerPadding];
+    rangeMissing = undefined;
     return scale;
   };
 
@@ -92,18 +104,18 @@ function newOrdinal(domain, ranger) {
   };
 
   scale.rangeExtent = function() {
-    var t = ranger.a[0], start = t[0], stop = t[t.length - 1];
+    var t = rangeArguments[0], start = t[0], stop = t[t.length - 1];
     if (stop < start) t = stop, stop = start, start = t;
     return [start, stop];
   };
 
   scale.copy = function() {
-    return newOrdinal(domain, ranger);
+    return newOrdinal(domain, rangeMethod, rangeArguments);
   };
 
   return scale.domain(domain);
 }
 
 export default function() {
-  return newOrdinal([], {t: "range", a: [[]]});
+  return newOrdinal([], "range", [[]]);
 };

--- a/test/ordinal-test.js
+++ b/test/ordinal-test.js
@@ -1,6 +1,8 @@
 var tape = require("tape"),
     scale = require("../");
 
+require("./inDelta");
+
 tape("ordinal() has the expected defaults", function(test) {
   var s = scale.ordinal();
   test.deepEqual(s.domain(), []);


### PR DESCRIPTION
Not sure about the API for this, but it’s a start. TODO

- [ ] Expose the `recycle` symbol? Probably not necessary.
- [ ] There’s no way to inspect whether recycling is enabled.
- [ ] But then, there’s also no way to inspect the range padding, either.
- [ ] Only recompute the range if the domain length changes AND the rangeMethod isn’t `"range"`?