### PR TITLE
Exp scale

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,10 @@ export {
 } from "./src/band";
 
 export {
+  default as scaleExp
+} from "./src/exp";
+
+export {
   default as scaleIdentity
 } from "./src/identity";
 

--- a/src/exp.js
+++ b/src/exp.js
@@ -12,6 +12,7 @@ export default function exp() {
 
   function rescale() {
     log = logp(base);
+    pow = powp(base);
     return scale;
   }
 

--- a/src/exp.js
+++ b/src/exp.js
@@ -1,0 +1,44 @@
+import constant from "./constant";
+import {linearish} from "./linear";
+import { logp, powp } from "./log";
+import {default as continuous, copy, deinterpolateLinear} from "./continuous";
+
+export default function exp() {
+  var base = Math.E,
+      log = logp(base),
+      pow = powp(base),
+      scale = continuous(deinterpolate, interpolate).range([1, base]),
+      domain = scale.domain;
+
+  function rescale() {
+    log = logp(base);
+    return scale;
+  }
+
+  function deinterpolate(a, b) {
+    a = pow(a);
+    b = pow(b) - a;
+    if (!b) return constant(b);
+    return function(x) {
+      return (pow(x) - a) / b;
+    };
+  }
+
+  function interpolate(a, b) {
+    a = pow(a);
+    b = pow(b) - a;
+    return function(t) {
+      return log(b * t + a);
+    };
+  }
+
+  scale.base = function(_) {
+    return arguments.length ? (base = +_, rescale()) : base;
+  };
+
+  scale.copy = function() {
+    return copy(scale, exp().base(base));
+  };
+
+  return linearish(scale);
+};

--- a/src/exp.js
+++ b/src/exp.js
@@ -1,6 +1,6 @@
 import constant from "./constant";
 import {linearish} from "./linear";
-import { logp, powp } from "./log";
+import {logp, powp} from "./log";
 import {default as continuous, copy, deinterpolateLinear} from "./continuous";
 
 export default function exp() {

--- a/src/log.js
+++ b/src/log.js
@@ -23,18 +23,18 @@ function pow10(x) {
   return isFinite(x) ? +("1e" + x) : x < 0 ? 0 : x;
 }
 
-function powp(base) {
+export function powp(base) {
   return base === 10 ? pow10
       : base === Math.E ? Math.exp
       : function(x) { return Math.pow(base, x); };
 }
 
-function logp(base) {
+export function logp(base) {
   return base === Math.E ? Math.log
       : base === 10 && Math.log10
       || base === 2 && Math.log2
       || (base = Math.log(base), function(x) { return Math.log(x) / base; });
-}
+};
 
 function reflect(f) {
   return function(x) {

--- a/test/exp-test.js
+++ b/test/exp-test.js
@@ -1,0 +1,40 @@
+var tape = require("tape"),
+    scale = require("../");
+
+require("./inDelta");
+
+tape("scaleExp() has the expected defaults", function(test) {
+  var s = scale.scaleExp();
+  test.deepEqual(s.domain(), [0, 1]);
+  test.deepEqual(s.range(), [1, Math.E]);
+  test.equal(s.clamp(), false);
+  test.equal(s.base(), Math.E);
+  test.end();
+});
+
+tape("exp(x) maps a domain value x to a range value y", function(test) {
+  var s = scale.scaleExp();
+  test.equal(s(0), 1);
+  test.equal(s(1), Math.E);
+  test.equal(s(2), Math.E * Math.E);
+  test.end();
+});
+
+tape("exp(x) maps an empty domain to the range start", function(test) {
+  test.equal(scale.scaleExp().domain([0, 0]).range([1, 2])(0), 1);
+  test.equal(scale.scaleExp().domain([0, 0]).range([2, 1])(1), 2);
+  test.end();
+});
+
+tape("exp.invert(y) maps a range value y to a domain value x", function(test) {
+  var s = scale.scaleExp();
+  test.inDelta(s.invert(1), 0);
+  test.inDelta(s.invert(Math.E), 1);
+  test.inDelta(s.invert(Math.E*Math.E), 2);
+
+  s.base(10);
+  test.inDelta(s.invert(0.01), -2);
+  test.inDelta(s.invert(1), 0);
+  test.inDelta(s.invert(100), 2);
+  test.end();
+});

--- a/test/exp-test.js
+++ b/test/exp-test.js
@@ -17,6 +17,12 @@ tape("exp(x) maps a domain value x to a range value y", function(test) {
   test.equal(s(0), 1);
   test.equal(s(1), Math.E);
   test.equal(s(2), Math.E * Math.E);
+
+  s.domain([0, 2]).range([1, 100]);
+  test.equal(s(0), 1);
+  test.equal(s(1), 10);
+  test.equal(s(2), 100);
+
   test.end();
 });
 

--- a/test/exp-test.js
+++ b/test/exp-test.js
@@ -18,10 +18,30 @@ tape("exp(x) maps a domain value x to a range value y", function(test) {
   test.equal(s(1), Math.E);
   test.equal(s(2), Math.E * Math.E);
 
-  s.domain([0, 2]).range([1, 100]);
-  test.equal(s(0), 1);
-  test.equal(s(1), 10);
-  test.equal(s(2), 100);
+  s = s.base(10);
+  s = s.domain([0, 5]).range([1e0, 1e5]);
+  test.equal(s(0), 1e0);
+  test.equal(s(1), 1e1);
+  test.equal(s(2), 1e2);
+  test.equal(s(3), 1e3);
+  test.equal(s(4), 1e4);
+  test.equal(s(5), 1e5);
+
+  s = s.domain([0, 5]).range([1e5, 1e10]);
+  test.equal(s(0), 1e5);
+  test.equal(s(1), 1e6);
+  test.equal(s(2), 1e7);
+  test.equal(s(3), 1e8);
+  test.equal(s(4), 1e9);
+  test.equal(s(5), 1e10);
+
+  s = s.domain([5, 10]).range([1e2, 1e7]);
+  test.equal(s(5), 1e2);
+  test.equal(s(6), 1e3);
+  test.equal(s(7), 1e4);
+  test.equal(s(8), 1e5);
+  test.equal(s(9), 1e6);
+  test.equal(s(10), 1e7);
 
   test.end();
 });


### PR DESCRIPTION
I've added an exponential scale. This is the inverse of the logarithmic scale. It's not sufficient to merely use `scaleLog().invert` because that's just a method, not a full scale object, so it doesn't work happily with many other APIs like axis generators.

I've neglected to write any documentation in this first commit because I want to get feedback first. I've also not written quite so many tests as perhaps I should, and much of the code elsewhere in this repo shows scars of having dealt with wacky inputs; I haven't tried very hard to anticipate all the possible wackiness out there and have left things pretty simple.