### PR TITLE
Use linear ticks when the log domain is small compared to min.

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -81,7 +81,11 @@ export default function log() {
 
     if (!(base % 1) && j - i < n) {
       i = Math.round(i) - 1, j = Math.round(j) + 1;
-      if (u > 0) for (; i < j; ++i) {
+      var testI = i;
+      while(pows(testI) * base < u) testI++;
+      if (v - u < pows(testI)) {
+        z = ticks(u, v, n);
+      } else if (u > 0) for (; i < j; ++i) {
         for (k = 1, p = pows(i); k < base; ++k) {
           t = p * k;
           if (t < u) continue;

--- a/test/log-test.js
+++ b/test/log-test.js
@@ -299,6 +299,14 @@ tape("log.ticks() generates the expected power-of-ten ticks for small domains", 
   test.end();
 });
 
+tape("log.ticks() generates linear ticks when the domain is small compared to the minimum value", function(test) {
+  var s = scale.scaleLog();
+  test.deepEqual(s.domain([41, 42]).ticks(), [41, 41.1, 41.2, 41.3, 41.4, 41.5, 41.6, 41.7, 41.8, 41.9, 42]);
+  test.deepEqual(s.domain([42, 41]).ticks(), [42, 41.9, 41.8, 41.7, 41.6, 41.5, 41.4, 41.3, 41.2, 41.1, 41]);
+  test.deepEqual(s.domain([1600, 1400]).ticks(), [1600, 1580, 1560, 1540, 1520, 1500, 1480, 1460, 1440, 1420, 1400]);
+  test.end();
+});
+
 tape("log.base(base).ticks() generates the expected power-of-base ticks", function(test) {
   var s = scale.scaleLog().base(Math.E);
   test.deepEqual(s.domain([0.1, 100]).ticks().map(round), [0.135335283237, 0.367879441171, 1, 2.718281828459, 7.389056098931, 20.085536923188, 54.598150033144]);


### PR DESCRIPTION
Fix #44 by reverting to a linear scale when domain is relatively small.
