### PR TITLE
Adds ESLint as a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "d3-time-format": "~0.3.0"
   },
   "devDependencies": {
+    "eslint": "1.10",
     "json2module": "0.0",
     "rollup": "0.26",
     "tape": "4",


### PR DESCRIPTION
Specifies ESLint 1.10, due to lint not passing with ESLint 2. This helps build in case ESLint isn't installed globally, or is installed globally, but of an incompatible version. Version 2 of ESLint complains of ` Parsing error: 'import' and 'export' may appear only with 'sourceType: module'`

For the pertaining ESLint 1 -> 2 change see `modules` in http://eslint.org/docs/user-guide/migrating-to-2.0.0#language-options

From the fact that ESLint seems to be at 1.x globally across D3 modules I assume it shouldn't be bumped to 2.0 but if so, glad to convert.

