### PR TITLE
Edge Browser Bug Fix (.call => .apply)

### DIFF
--- a/src/continuous.js
+++ b/src/continuous.js
@@ -90,15 +90,15 @@ export default function continuous(deinterpolate, reinterpolate) {
   };
 
   scale.domain = function(_) {
-    return arguments.length ? (domain = map.call(_, number), rescale()) : domain.slice();
+    return arguments.length ? (domain = map.apply(_, [number]), rescale()) : domain.slice();
   };
 
   scale.range = function(_) {
-    return arguments.length ? (range = slice.call(_), rescale()) : range.slice();
+    return arguments.length ? (range = slice.apply(_), rescale()) : range.slice();
   };
 
   scale.rangeRound = function(_) {
-    return range = slice.call(_), interpolate = interpolateRound, rescale();
+    return range = slice.apply(_), interpolate = interpolateRound, rescale();
   };
 
   scale.clamp = function(_) {

--- a/src/identity.js
+++ b/src/identity.js
@@ -12,7 +12,7 @@ export default function identity() {
   scale.invert = scale;
 
   scale.domain = scale.range = function(_) {
-    return arguments.length ? (domain = map.call(_, number), scale) : domain.slice();
+    return arguments.length ? (domain = map.apply(_, [number]), scale) : domain.slice();
   };
 
   scale.copy = function() {

--- a/src/ordinal.js
+++ b/src/ordinal.js
@@ -8,7 +8,7 @@ export default function ordinal(range) {
       domain = [],
       unknown = implicit;
 
-  range = range == null ? [] : slice.call(range);
+  range = range == null ? [] : slice.apply(range);
 
   function scale(d) {
     var key = d + "", i = index.get(key);
@@ -28,7 +28,7 @@ export default function ordinal(range) {
   };
 
   scale.range = function(_) {
-    return arguments.length ? (range = slice.call(_), scale) : range.slice();
+    return arguments.length ? (range = slice.apply(_), scale) : range.slice();
   };
 
   scale.unknown = function(_) {

--- a/src/quantile.js
+++ b/src/quantile.js
@@ -34,7 +34,7 @@ export default function quantile() {
   };
 
   scale.range = function(_) {
-    return arguments.length ? (range = slice.call(_), rescale()) : range.slice();
+    return arguments.length ? (range = slice.apply(_), rescale()) : range.slice();
   };
 
   scale.quantiles = function() {

--- a/src/quantize.js
+++ b/src/quantize.js
@@ -25,7 +25,7 @@ export default function quantize() {
   };
 
   scale.range = function(_) {
-    return arguments.length ? (n = (range = slice.call(_)).length - 1, rescale()) : range.slice();
+    return arguments.length ? (n = (range = slice.apply(_)).length - 1, rescale()) : range.slice();
   };
 
   scale.invertExtent = function(y) {

--- a/src/threshold.js
+++ b/src/threshold.js
@@ -11,11 +11,11 @@ export default function threshold() {
   }
 
   scale.domain = function(_) {
-    return arguments.length ? (domain = slice.call(_), n = Math.min(domain.length, range.length - 1), scale) : domain.slice();
+    return arguments.length ? (domain = slice.apply(_), n = Math.min(domain.length, range.length - 1), scale) : domain.slice();
   };
 
   scale.range = function(_) {
-    return arguments.length ? (range = slice.call(_), n = Math.min(domain.length, range.length - 1), scale) : range.slice();
+    return arguments.length ? (range = slice.apply(_), n = Math.min(domain.length, range.length - 1), scale) : range.slice();
   };
 
   scale.invertExtent = function(y) {

--- a/src/time.js
+++ b/src/time.js
@@ -97,7 +97,7 @@ export function calendar(year, month, week, day, hour, minute, second, milliseco
   };
 
   scale.domain = function(_) {
-    return arguments.length ? domain(map.call(_, number)) : domain().map(date);
+    return arguments.length ? domain(map.apply(_, [number])) : domain().map(date);
   };
 
   scale.ticks = function(interval, step) {


### PR DESCRIPTION
### The Bug
In working with `d3-scale` in Edge, I came across this gross bug involving `.call`: https://github.com/Microsoft/ChakraCore/issues/1415

### tl;dr
inline `.call` snippets don't execute and instead return the function.

As a result I've gone ahead and replaced all instances of `.call` with `.apply`, since it doesn't seem like Microsoft has any plans to fix this in current versions of Windows with Edge.

If there's an alternative fix for this, I'd be happy to make any changes.