### PR TITLE
Allow for unlimiter outer padding in band scale. Fixes #102.

### DIFF
--- a/src/band.js
+++ b/src/band.js
@@ -62,7 +62,7 @@ export default function band() {
   };
 
   scale.paddingOuter = function(_) {
-    return arguments.length ? (paddingOuter = Math.max(0, Math.min(1, _)), rescale()) : paddingOuter;
+    return arguments.length ? (paddingOuter = Math.max(0, _), rescale()) : paddingOuter;
   };
 
   scale.align = function(_) {

--- a/test/band-test.js
+++ b/test/band-test.js
@@ -187,11 +187,11 @@ tape("band.paddingOuter(p) specifies the outer padding p", function(test) {
   test.end();
 });
 
-tape("band.paddingOuter(p) coerces p to a number in [0, 1]", function(test) {
+tape("band.paddingOuter(p) coerces p to a number in [0, Infinity]", function(test) {
   var s = scale.scaleBand();
   test.equal(s.paddingOuter("1.0").paddingOuter(), 1);
   test.equal(s.paddingOuter("-1.0").paddingOuter(), 0);
-  test.equal(s.paddingOuter("2.0").paddingOuter(), 1);
+  test.equal(s.paddingOuter("2.0").paddingOuter(), 2);
   test.ok(Number.isNaN(s.paddingOuter(NaN).paddingOuter()));
   test.end();
 });


### PR DESCRIPTION
* removes the clipping of outer padding values > 1. 