### PR TITLE
Fix for nice() at certain scales.

### DIFF
--- a/src/linear.js
+++ b/src/linear.js
@@ -19,11 +19,13 @@ export function linearish(scale) {
     var d = domain(),
         i = d.length - 1,
         n = count == null ? 10 : count,
-        step = tickStep(d[0], d[i], n),
-        start = Math.floor(d[0] / step) * step,
-        stop = Math.ceil(d[i] / step) * step;
+        start = d[0],
+        stop = d[i],
+        step = tickStep(start, stop, n);
 
     if (step) {
+      start = Math.floor(start / step) * step;
+      stop = Math.ceil(stop / step) * step;
       step = tickStep(start, stop, n);
       d[0] = Math.floor(start / step) * step;
       d[i] = Math.ceil(stop / step) * step;

--- a/src/linear.js
+++ b/src/linear.js
@@ -19,12 +19,12 @@ export function linearish(scale) {
     var d = domain(),
         i = d.length - 1,
         n = count == null ? 10 : count,
-        start = d[0],
-        stop = d[i],
-        step = tickStep(start, stop, n);
+        step = tickStep(d[0], d[i], n),
+        start = Math.floor(d[0] / step) * step,
+        stop = Math.ceil(d[i] / step) * step;
 
     if (step) {
-      step = tickStep(Math.floor(start / step) * step, Math.ceil(stop / step) * step, n);
+      step = tickStep(start, stop, n);
       d[0] = Math.floor(start / step) * step;
       d[i] = Math.ceil(stop / step) * step;
       domain(d);

--- a/test/linear-test.js
+++ b/test/linear-test.js
@@ -230,6 +230,8 @@ tape("linear.nice(count) nices the domain, extending it to round numbers", funct
   test.deepEqual(scale.scaleLinear().domain([0.7, 11.001]).nice(10).domain(), [0, 12]);
   test.deepEqual(scale.scaleLinear().domain([123.1, 6.7]).nice(10).domain(), [130, 0]);
   test.deepEqual(scale.scaleLinear().domain([0, 0.49]).nice(10).domain(), [0, 0.5]);
+  test.deepEqual(scale.scaleLinear().domain([0, 14.1]).nice(5).domain(), [0, 20]);
+  test.deepEqual(scale.scaleLinear().domain([0, 15]).nice(5).domain(), [0, 20]);
   test.end();
 });
 


### PR DESCRIPTION
The fix for #9 was causing me some problems with scale.  I was getting the following behavior, which I'm pretty sure isn't expected:

``` javascript
const scale = d3.scaleLinear().domain([0, 14.1]).nice(5);
scale.domain(); // [0, 15]
scale.ticks(5); // [0, 2, 4, 6, 8, 10, 12, 14]
```
I was essentially having the reverse problem to the other users in in the issue.  When stepping through, `nice()` was selecting a step size of `2` in its first calculation, then going back to `5` for its second (and thus not updating the domain).  However, `ticks()` was calculating `2` as its step size, and therefore only going up to 14.

These are not the only numbers where I was seeing this problem, I just picked these ones in particular for an example.

The fix here updates the domain twice, instead of only updating the step size twice.  I think it fixes my problem, without adversely affecting any other situations.  In the example I gave, we now have

``` javascript
const scale = d3.scaleLinear().domain([0, 15]).nice(5);
scale.domain(); // [0, 20]
scale.ticks(5); // [0, 5, 10, 15, 20]
```

I think under ideal circumstances we'd have, 

``` javascript
scale.domain([0, 15]).ticks(5) // [0, 5, 10, 15]
```

But changing that would require changing the tick error constants, and I'm guessing there's a reason they are the way they are.