### PR TITLE
Allow Tiny Intervals

### DIFF
--- a/src/time.js
+++ b/src/time.js
@@ -84,7 +84,7 @@ export function calendar(year, month, week, day, hour, minute, second, milliseco
         step = i[1];
         interval = i[0];
       } else {
-        step = tickStep(start, stop, interval);
+        step = Math.max(tickStep(start, stop, interval), 1);
         interval = millisecond;
       }
     }


### PR DESCRIPTION
If you get close enough to the millisecond values things start to get screwy. This change essentially ensures that ticks always come back even if looking at a range of only a few milliseconds.