### PR TITLE
Clarify definitions for band scale paddingInner and paddingOuter

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,11 +755,11 @@ If *round* is specified, enables or disables rounding accordingly. If rounding i
 
 <a name="band_paddingInner" href="#band_paddingInner">#</a> <i>band</i>.<b>paddingInner</b>([<i>padding</i>]) [<>](https://github.com/d3/d3-scale/blob/master/src/band.js#L60 "Source")
 
-If *padding* is specified, sets the inner padding to the specified value which must be in the range [0, 1]. If *padding* is not specified, returns the current inner padding which defaults to 0. The inner padding determines the ratio of the range that is reserved for blank space between bands.
+If *padding* is specified, sets the inner padding to the specified value which must be in the range [0, 1]. If *padding* is not specified, returns the current inner padding which defaults to 0. The inner padding determines the proportion of the scale's [step](#band_step) length that is reserved for blank space between bands.
 
 <a name="band_paddingOuter" href="#band_paddingOuter">#</a> <i>band</i>.<b>paddingOuter</b>([<i>padding</i>]) [<>](https://github.com/d3/d3-scale/blob/master/src/band.js#L64 "Source")
 
-If *padding* is specified, sets the outer padding to the specified value which must be in the range [0, 1]. If *padding* is not specified, returns the current outer padding which defaults to 0. The outer padding determines the ratio of the range that is reserved for blank space before the first band and after the last band.
+If *padding* is specified, sets the outer padding to the specified value which must be in the range [0, 1]. If *padding* is not specified, returns the current outer padding which defaults to 0. The outer padding determines the proportion of the scale's [step](#band_step) length that is reserved for blank space before the first band and after the last band.
 
 <a name="band_padding" href="#band_padding">#</a> <i>band</i>.<b>padding</b>([<i>padding</i>]) [<>](https://github.com/d3/d3-scale/blob/master/src/band.js#L56 "Source")
 


### PR DESCRIPTION
The current wording of the definitions of the band scale paddingInner and paddingOuter methods are confusing. They state that the padding values "determines the ratio of the range that is reserved for blank space". However, the padding values are actually the proportion of the step (not the range) that is used for padding. 

I think the new wording is a bit clearer. Alternatively, I could write up a more detailed description, but I was trying to keep it concise (like the rest of the API reference).