### PR TITLE
Add symlog and compound scales

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ var x = d3.scaleLinear();
 * [Quantile](#quantile-scales)
 * [Threshold](#threshold-scales)
 * [Ordinal](#ordinal-scales) ([Band](#band-scales), [Point](#point-scales))
+* [Compound](#compound-scales) ([Symlog](#symlog-scales))
 
 ### Continuous Scales
 
@@ -838,3 +839,41 @@ Returns the distance between the starts of adjacent points.
 <a name="point_copy" href="#point_copy">#</a> <i>point</i>.<b>copy</b>()
 
 Returns an exact copy of this scale. Changes to this scale will not affect the returned scale, and vice versa.
+
+### Compound Scales
+
+A compound scale is a scale that delegates to any number of other scales. Its range and domain are inclusive to each provided scale.
+
+Compound scales may be used as building blocks to create scales that behave differently over different portions of the input domain, such as [symlog scales](#symlog-scales).
+
+<a name="scaleCompound" href="#scaleCompound">#</a> d3.<b>scaleCompound</b>(<i>[scale, ...]</i>) [<>](https://github.com/d3/d3-scale/blob/master/src/compound.js "Source")
+
+Constructs a new [compound scale](#compound-scales), delegating to the provided scales. Returns null if no scales provided.
+
+<a name="compound_domain" href="#compound_domain">#</a> <i>compound</i>.<b>domain</b>() [<>](https://github.com/d3/d3-scale/blob/master/src/compound.js#L18 "Source")
+
+Returns the domain inclusive of the [min, max] of all delegated scales.
+
+<a name="compound_range" href="#compound_range">#</a> <i>compound</i>.<b>range</b>() [<>](https://github.com/d3/d3-scale/blob/master/src/compound.js#L28 "Source")
+
+Returns the range inclusive of the [min, max] of all delegated scales.
+
+#### Symlog Scales
+
+Inspired by [symlog scales in Matplotlib](https://matplotlib.org/gallery/scales/symlog_demo.html), a symlog scale is a compound scale that delegates to the following scales:
+
+* Log scale over domain [-Infinity, -1]
+* Linear scale over domain [-1, 1]
+* Log scale over domain [1, Infinity]
+
+<a name="scaleSymlog" href="#scaleCompound">#</a> d3.<b>scaleSymlog</b>() [<>](https://github.com/d3/d3-scale/blob/master/src/symlog.js "Source")
+
+Constructs a new [symlog scale](#symlog-scales), defaulting to a [linear scale](#linear-scales) over domain [0, 1] and range [0, 1].
+
+<a name="symlog_domain" href="#symlog_domain">#</a> <i>symlog</i>.<b>domain</b>([<i>domain</i>]) [<>](https://github.com/d3/d3-scale/blob/master/src/symlog.js#L75 "Source")
+
+If *domain* is specified, sets the scale’s domain to the specified array of numbers. If *domain* is not specified, returns the [compound domain](#compound_domain) of this scale.
+
+<a name="symlog_range" href="#symlog_range">#</a> <i>symlog</i>.<b>range</b>([<i>range</i>]) [<>](https://github.com/d3/d3-scale/blob/master/src/symlog.js#L79 "Source")
+
+If *range* is specified, sets the scale’s range to the specified array of numbers. If *range* is not specified, returns the [compound range](#compound_range) of this scale.

--- a/index.js
+++ b/index.js
@@ -4,6 +4,10 @@ export {
 } from "./src/band";
 
 export {
+  default as scaleCompound
+} from "./src/compound";
+
+export {
   default as scaleIdentity
 } from "./src/identity";
 
@@ -32,6 +36,10 @@ export {
 export {
   default as scaleQuantize
 } from "./src/quantize";
+
+export {
+  default as scaleSymlog
+} from "./src/symlog";
 
 export {
   default as scaleThreshold

--- a/src/compound.js
+++ b/src/compound.js
@@ -1,0 +1,47 @@
+export default function compound() {
+  var scales = [].slice.call(arguments);
+  if (scales.length === 0) {
+    return null;
+  }
+
+  function scale(x) {
+    for (var i = 0; i < scales.length; i++) {
+      var domain = scales[i].domain();
+      if (Math.min.apply(null, domain) <= x && x <= Math.max.apply(null, domain)) {
+        return scales[i](x);
+      }
+    }
+    // Fallback to last scale
+    return scales[scales.length - 1](x);
+  }
+
+  scale.domain = function() {
+    if (arguments.length) {
+      throw 'Setting a domain is not supported on compound scales';
+    }
+    var values = [].concat.apply([], scales.map(function(s) { return s.domain(); }));
+    var domain = [Math.min.apply(null, values), Math.max.apply(null, values)];
+    if (values[0] > values[1]) domain = domain.slice().reverse();
+    return domain;
+  };
+
+  scale.range = function() {
+    if (arguments.length) {
+      throw 'Setting a range is not supported on compound scales';
+    }
+    var values = [].concat.apply([], scales.map(function(s) { return s.range(); }));
+    var range = [Math.min.apply(null, values), Math.max.apply(null, values)];
+    if (values[0] > values[1]) range = range.slice().reverse();
+    return range;
+  };
+
+  scale.copy = function() {
+    return compound.apply(null, scales.map(function(s) { return s.copy(); }));
+  };
+
+  scale.scales = function(_) {
+    return arguments.length ? (scales = _, scale) : scales;
+  };
+
+  return scale;
+}

--- a/src/symlog.js
+++ b/src/symlog.js
@@ -1,0 +1,84 @@
+import {default as compound} from "./compound";
+import {default as linear} from "./linear";
+import {default as log} from "./log";
+
+function intersection(r1, r2) {
+  var reverse = r1[0] > r1[1];
+  if (reverse) r1 = r1.slice().reverse();
+
+  var min = r1[0] < r2[0] ? r1 : r2;
+  var max = min === r1 ? r2 : r1;
+  if (min[1] < max[0]) return null;
+
+  var section = [max[0], min[1] < max[1] ? min[1] : max[1]];
+  if (section[0] === section[1]) return null;
+
+  if (reverse) section = section.slice().reverse();
+  return section;
+}
+
+function rescale(range, domain) {
+  var logScale = log(),
+      d,
+      parts = [];
+
+  // Negative log scale
+  if (d = intersection(domain, [Number.NEGATIVE_INFINITY, -1])) {
+    parts.push({
+      domain: d,
+      type: log,
+      extent: logScale(Math.abs(d[1] - d[0]) + 1) - logScale(1)
+    });
+  }
+
+  // Linear scale
+  if (d = intersection(domain, [-1, 1])) {
+    parts.push({
+      domain: d,
+      type: linear,
+      extent: Math.abs(d[1] - d[0]) * (logScale(2) - logScale(1))
+    });
+  }
+
+  // Positive log scale
+  if (d = intersection(domain, [1, Number.POSITIVE_INFINITY])) {
+    parts.push({
+      domain: d,
+      type: log,
+      extent: logScale(Math.abs(d[1] - d[0]) + 1) - logScale(1)
+    });
+  }
+
+  // Create the scales
+  var scales = [];
+  var rangeSize = range[1] - range[0];
+  var rangeExtent = parts.reduce(function (acc, part) { return part.extent + acc; }, 0);
+  var rangeStart = range[0];
+  for (var i = 0; i < parts.length; i++) {
+    var part = parts[i];
+    if (part.extent > 0) {
+      var ratio = part.extent / rangeExtent;
+      var next = (i === parts.length - 1) ? range[1] : rangeStart + ratio * rangeSize;
+      scales.push(part.type().domain(part.domain).range([rangeStart, next]));
+      rangeStart = next;
+    }
+  }
+
+  return scales;
+}
+
+export default function symlog() {
+  var scale = compound(linear()),
+      compoundRange = scale.range,
+      compoundDomain = scale.domain;
+
+  scale.domain = function(_) {
+    return arguments.length ? scale.scales(rescale(scale.range(), _)) : compoundDomain();
+  };
+
+  scale.range = function(_) {
+    return arguments.length ? scale.scales(rescale(_, scale.domain())) : compoundRange();
+  };
+
+  return scale;
+}

--- a/test/compound-test.js
+++ b/test/compound-test.js
@@ -1,0 +1,61 @@
+var tape = require("tape"),
+    scale = require("../");
+
+tape("scaleCompound() requires arguments", function(test) {
+  test.equal(scale.scaleCompound(), null);
+  test.end();
+});
+
+tape("compound.domain() doesn't accept arguments", function(test) {
+  var x = scale.scaleCompound(scale.scaleLinear());
+  test.throws(function () { x.domain([1, 0]); });
+  test.end();
+});
+
+tape("compound.range() doesn't accept arguments", function(test) {
+  var x = scale.scaleCompound(scale.scaleLinear());
+  test.throws(function () { x.domain([1, 0]); });
+  test.end();
+});
+
+tape("compound.domain() returns inclusive domain", function(test) {
+  var x = scale.scaleCompound(scale.scaleLinear().domain([0, 10]), scale.scaleLinear().domain([8, 20]));
+  test.deepEquals(x.domain(), [0, 20]);
+  test.end();
+});
+
+tape("compound.range() returns inclusive range", function(test) {
+  var x = scale.scaleCompound(scale.scaleLinear().range([0, 10]), scale.scaleLinear().range([8, 20]));
+  test.deepEquals(x.range(), [0, 20]);
+  test.end();
+});
+
+tape("compound() prefers first scale on bounds", function(test) {
+  var linear = scale.scaleLinear().domain([0, 10]);
+  var log = scale.scaleLog().domain([8, 20]);
+  var x = scale.scaleCompound(linear, log);
+  test.equal(x(0), linear(0));
+  test.equal(x(8), linear(8));
+  test.equal(x(10), linear(10));
+  test.end();
+});
+
+tape("compound() delegates to second scale out of bounds of first", function(test) {
+  var linear = scale.scaleLinear().domain([0, 10]);
+  var log = scale.scaleLog().domain([8, 20]);
+  var x = scale.scaleCompound(linear, log);
+  test.equal(x(11), log(11));
+  test.equal(x(20), log(20));
+  test.end();
+});
+
+tape("compound() returns last scale when all out of bounds", function(test) {
+  var linear = scale.scaleLinear().domain([0, 10]);
+  var log = scale.scaleLog().domain([8, 20]);
+  var x = scale.scaleCompound(linear, log);
+  test.equal(x(21), log(21));
+  test.equal(x(200), log(200));
+  test.ok(isNaN(x(-1)));
+  test.ok(isNaN(x(-100)));
+  test.end();
+});

--- a/test/symlog-test.js
+++ b/test/symlog-test.js
@@ -1,0 +1,127 @@
+var tape = require("tape"),
+    scale = require("../");
+
+function assertScaleValue(test, scale1, scale2, value) {
+  var expected = scale2(value);
+  test.equal(scale1(value), expected);
+  test.true(isFinite(expected));
+}
+
+tape("scaleSymlog() maps domain [-1, 1] to linear scale", function(test) {
+  var linear = scale.scaleLinear().domain([-1, 1]).range([10, 0]);
+  var symlog = scale.scaleSymlog().domain([-1, 1]).range([10, 0]);
+
+  var scales = symlog.scales();
+  test.equal(scales.length, 1);
+
+  // Linear range 0 - 1
+  test.equal(symlog(-1), linear(-1));
+  test.equal(symlog(-0.75), linear(-0.75));
+  test.equal(symlog(-0.5), linear(-0.5));
+  test.equal(symlog(-0.25), linear(-0.25));
+  test.equal(symlog(0), linear(0));
+  test.equal(symlog(0.25), linear(0.25));
+  test.equal(symlog(0.5), linear(0.5));
+  test.equal(symlog(0.75), linear(0.75));
+  test.equal(symlog(1), linear(1));
+
+  test.end();
+});
+
+tape("scaleSymlog() maps domain [1, 10] to logarithm scale", function(test) {
+  var log = scale.scaleLog().domain([1, 10]).range([1, 10]);
+  var symlog = scale.scaleSymlog().domain([1, 10]).range([1, 10]);
+
+  var scales = symlog.scales();
+  test.equal(scales.length, 1);
+
+  // Log range 1 - 10
+  test.equal(symlog(1), log(1));
+  test.equal(symlog(2), log(2));
+  test.equal(symlog(5), log(5));
+  test.equal(symlog(10), log(10));
+  test.end();
+});
+
+tape("scaleSymlog() maps domain [-1, -10] to logarithm scale", function(test) {
+  var log = scale.scaleLog().domain([-1, -10]).range([-1, -10]);
+  var symlog = scale.scaleSymlog().domain([-1, -10]).range([-1, -10]);
+
+  var scales = symlog.scales();
+  test.equal(scales.length, 1);
+
+  // Log range 1 - 10
+  test.equal(symlog(-1), log(-1));
+  test.equal(symlog(-2), log(-2));
+  test.equal(symlog(-5), log(-5));
+  test.equal(symlog(-10), log(-10));
+  test.end();
+});
+
+tape("scaleSymlog() maps domain [-2, 2] to two logarithm and one linear scales", function(test) {
+  var symlog = scale.scaleSymlog().domain([-2, 2]).range([0, 1]);
+  var scales = symlog.scales();
+
+  test.equal(scales.length, 3);
+  test.deepEqual(scales[0].domain(), [-2, -1]);
+  test.deepEqual(scales[1].domain(), [-1, 1]);
+  test.deepEqual(scales[2].domain(), [1, 2]);
+  test.deepEqual(scales[0].range(), [0, 0.25]);
+  test.deepEqual(scales[1].range(), [0.25, 0.75]);
+  test.deepEqual(scales[2].range(), [0.75, 1.0]);
+
+  assertScaleValue(test, symlog, scales[0], -2);
+  assertScaleValue(test, symlog, scales[0], -1.5);
+  assertScaleValue(test, symlog, scales[0], -1);
+  assertScaleValue(test, symlog, scales[1], -1);
+  assertScaleValue(test, symlog, scales[1], -0.5);
+  assertScaleValue(test, symlog, scales[1], 0);
+  assertScaleValue(test, symlog, scales[1], 0.5);
+  assertScaleValue(test, symlog, scales[1], 1);
+  assertScaleValue(test, symlog, scales[2], 1);
+  assertScaleValue(test, symlog, scales[2], 1.5);
+  assertScaleValue(test, symlog, scales[2], 2);
+
+  test.end();
+});
+
+tape("scaleSymlog() maps domain [-10, 10] to two logarithm and one linear scales", function(test) {
+  var symlog = scale.scaleSymlog().domain([-10, 10]).range([0, 1]);
+  var scales = symlog.scales();
+
+  test.equal(scales.length, 3);
+  test.deepEqual(scales[0].domain(), [-10, -1]);
+  test.deepEqual(scales[1].domain(), [-1, 1]);
+  test.deepEqual(scales[2].domain(), [1, 10]);
+  test.deepEqual(scales[0].range(), [0, 0.38431089342012037]);
+  test.deepEqual(scales[1].range(), [0.38431089342012037, 0.6156891065798795]);
+  test.deepEqual(scales[2].range(), [0.6156891065798795, 1]);
+
+  assertScaleValue(test, symlog, scales[0], -10);
+  assertScaleValue(test, symlog, scales[0], -1);
+  assertScaleValue(test, symlog, scales[1], -1);
+  assertScaleValue(test, symlog, scales[1], -0.5);
+  assertScaleValue(test, symlog, scales[1], 0);
+  assertScaleValue(test, symlog, scales[1], 0.5);
+  assertScaleValue(test, symlog, scales[1], 1);
+  assertScaleValue(test, symlog, scales[2], 2);
+  assertScaleValue(test, symlog, scales[2], 5);
+  assertScaleValue(test, symlog, scales[2], 10);
+
+  test.end();
+});
+
+tape("scaleSymlog() maps domain [-1, 2]", function(test) {
+  var symlog = scale.scaleSymlog().domain([-1, 2]).range([0, 1]);
+  var scales = symlog.scales();
+
+  test.equal(scales.length, 2);
+  test.deepEqual(scales[0].domain(), [-1, 1]);
+  test.deepEqual(scales[1].domain(), [1, 2]);
+  test.deepEqual(scales[0].range(), [0, 2 / 3]);
+  test.deepEqual(scales[1].range(), [2 / 3, 1]);
+
+  assertScaleValue(test, symlog, scales[0], -1);
+
+  test.end();
+});


### PR DESCRIPTION
The motivation for this work is to produce Matplotlib-style "symlog" scaling, as described in #105. 

The PR adds the notion of a "compound scale", a scale that delegates to any number of other scales. Its range and domains are inclusive to each provided scale. The symlog scale is responsible for instantiating the compound scale given a range or domain, with:

```
Log scale: [-Infinity, -1]
Linear scale: [-1, 1]
Log scale: [1, Infinity]
```