### PR TITLE
Adding support for band.invert()

### DIFF
--- a/src/band.js
+++ b/src/band.js
@@ -29,6 +29,20 @@ export default function band() {
     return ordinalRange(reverse ? values.reverse() : values);
   }
 
+  scale.invert = function(_) {
+    var domainIndex,
+        n = domain().length,
+        reverse = range[1] < range[0],
+        start = range[reverse - 0],
+        stop = range[1 - reverse];
+    
+    if (_ < start + paddingOuter * step) domainIndex = 0;
+    else if (_ > stop - paddingOuter * step) domainIndex = n - 1;
+    else domainIndex = Math.floor((_ - start - paddingOuter * step) / step);
+    
+    return domain()[domainIndex];
+  }
+
   scale.domain = function(_) {
     return arguments.length ? (domain(_), rescale()) : domain();
   };

--- a/test/band-test.js
+++ b/test/band-test.js
@@ -135,6 +135,29 @@ tape("band.range(values) can be descending", function(test) {
   test.end();
 });
 
+tape("band.invert() return correct domain values", function(test) {
+  var s = scale.scaleBand().domain(["a", "b", "c"]).range([20, 140]);
+  test.equal(s.invert(-10), "a");
+  test.equal(s.invert(20), "a");
+  test.equal(s.invert(32), "a");
+  test.equal(s.invert(74), "b");
+  test.equal(s.invert(128), "c");
+  test.equal(s.invert(150), "c");
+  s.paddingInner(0.2);
+  s.paddingOuter(0.2);
+  test.equal(s.invert(-10), "a");
+  test.equal(s.invert(0), "a");
+  test.equal(s.invert(12), "a");
+  test.equal(s.invert(20), "a");
+  test.equal(s.invert(55), "a");
+  test.equal(s.invert(75), "b");
+  test.equal(s.invert(100), "b");
+  test.equal(s.invert(110), "c");
+  test.equal(s.invert(135), "c");
+  test.equal(s.invert(150), "c");
+  test.end();
+});
+
 tape("band.range(values) makes a copy of the specified range values", function(test) {
   var range = [1, 2],
       s = scale.scaleBand().range(range);


### PR DESCRIPTION
Band scale maps an array of discrete values to an array of bands which occupy whole range (padding can be treated as a band). As each point in range can be mapped to unique value from domain, invert function for band scale can be implemented.

I need this change for react-vis. Zoom for plots with ordinal values on X axe doesn't work.