### PR TITLE
d3.scaleDiverging for a descending domain

### DIFF
--- a/src/diverging.js
+++ b/src/diverging.js
@@ -10,6 +10,7 @@ function transformer() {
   var x0 = 0,
       x1 = 0.5,
       x2 = 1,
+      s = 1,
       t0,
       t1,
       t2,
@@ -21,11 +22,11 @@ function transformer() {
       unknown;
 
   function scale(x) {
-    return isNaN(x = +x) ? unknown : (x = 0.5 + ((x = +transform(x)) - t1) * (x < t1 ? k10 : k21), interpolator(clamp ? Math.max(0, Math.min(1, x)) : x));
+    return isNaN(x = +x) ? unknown : (x = 0.5 + ((x = +transform(x)) - t1) * (s * x < s * t1 ? k10 : k21), interpolator(clamp ? Math.max(0, Math.min(1, x)) : x));
   }
 
   scale.domain = function(_) {
-    return arguments.length ? ([x0, x1, x2] = _, t0 = transform(x0 = +x0), t1 = transform(x1 = +x1), t2 = transform(x2 = +x2), k10 = t0 === t1 ? 0 : 0.5 / (t1 - t0), k21 = t1 === t2 ? 0 : 0.5 / (t2 - t1), scale) : [x0, x1, x2];
+    return arguments.length ? ([x0, x1, x2] = _, t0 = transform(x0 = +x0), t1 = transform(x1 = +x1), t2 = transform(x2 = +x2), k10 = t0 === t1 ? 0 : 0.5 / (t1 - t0), k21 = t1 === t2 ? 0 : 0.5 / (t2 - t1), s = t1 < t0 ? -1 : 1, scale) : [x0, x1, x2];
   };
 
   scale.clamp = function(_) {

--- a/test/diverging-test.js
+++ b/test/diverging-test.js
@@ -57,6 +57,15 @@ tape("diverging.domain() handles a degenerate domain", function(test) {
   test.end();
 });
 
+tape("diverging.domain() handles a descending domain", function(test) {
+  var s = scale.scaleDiverging().domain([4, 2, 1]);
+  test.deepEqual(s.domain(), [4, 2, 1]);
+  test.equal(s( 1.2), 0.9);
+  test.equal(s( 2.0), 0.5);
+  test.equal(s( 3.0), 0.25);
+  test.end();
+});
+
 tape("diverging.domain() handles a non-numeric domain", function(test) {
   var s = scale.scaleDiverging().domain([NaN, 2, 3]);
   test.equal(isNaN(s.domain()[0]), true);


### PR DESCRIPTION
`d3.scaleDiverging().domain([2,0,-1])` should map `[2,0]` to `[0,0.5]`.

Makes `a` equivalent to `b` in:
```
  a = d3.scaleDiverging(d3.interpolateRdBu).domain([-1, 0, 2]);
  b = d3.scaleDiverging(t => d3.interpolateRdBu(1-t)).domain([2, 0, -1]);
```