### PR TITLE
[documentation] d3.scaleIdentity is not useful with brushes anymore 

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ If *constant* is specified, sets the symlog constant to the specified number and
 
 #### Identity Scales
 
-Identity scales are a special case of [linear scales](#linear-scales) where the domain and range are identical; the scale and its invert method are thus the identity function. These scales are occasionally useful when working with pixel coordinates, say in conjunction with an axis or brush. Identity scales do not support [rangeRound](#continuous_rangeRound), [clamp](#continuous_clamp) or [interpolate](#continuous_interpolate).
+Identity scales are a special case of [linear scales](#linear-scales) where the domain and range are identical; the scale and its invert method are thus the identity function. These scales are occasionally useful when working with pixel coordinates, say in conjunction with an axis. Identity scales do not support [rangeRound](#continuous_rangeRound), [clamp](#continuous_clamp) or [interpolate](#continuous_interpolate).
 
 <a name="scaleIdentity" href="#scaleIdentity">#</a> d3.<b>scaleIdentity</b>([<i>range</i>]) [<>](https://github.com/d3/d3-scale/blob/master/src/identity.js "Source")
 


### PR DESCRIPTION
since D3 4.0 (https://github.com/d3/d3/blob/master/CHANGES.md#brushes-d3-brush)