### PR TITLE
Bump d3-interpolate version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "d3-array": "1.2.0 - 2",
     "d3-format": "1",
-    "d3-interpolate": "1",
+    "d3-interpolate": "^1.2.0",
     "d3-time": "1",
     "d3-time-format": "2"
   },


### PR DESCRIPTION
This package depends on d3-interpolate's [piecewise](https://github.com/d3/d3-scale/blob/master/src/diverging.js#L1) function which was added in [d3-interpolate@1.2.0](https://github.com/d3/d3-interpolate/releases/tag/v1.2.0).

Ran into this in a monorepo where we already had a version of `d3-interpolate` installed, but it was an earlier version that was missing the `piecewise` function. Declaring the version number simple as `"1"` had the same effect as it being set to `"^1.0.0"`, so `yarn` didn't realize that a higher version was needed.