### PR TITLE
diverging.domain([x0, x1][, pivot]) sets the domain from a 2-element extent & pivot

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,9 +629,11 @@ If *interpolator* is an array, it represents the scale’s three-element output 
 
 See [*continuous*](#_continuous).
 
-<a name="diverging_domain" href="#diverging_domain">#</a> <i>diverging</i>.<b>domain</b>([<i>domain</i>]) · [Source](https://github.com/d3/d3-scale/blob/master/src/diverging.js), [Examples](https://observablehq.com/@d3/diverging-scales)
+<a name="diverging_domain" href="#diverging_domain">#</a> <i>diverging</i>.<b>domain</b>([<i>domain</i>][, <i>pivot</i>]) · [Source](https://github.com/d3/d3-scale/blob/master/src/diverging.js), [Examples](https://observablehq.com/@d3/diverging-scales)
 
-See [*continuous*.domain](#continuous_domain). Note that a diverging scale’s domain must be numeric and must contain exactly three values. The default domain is [0, 0.5, 1].
+If *domain* is specified with three values [x0, pivot, x1], sets the scale’s domain to the specified array. If *domain* contains two elements [x0, x1], inserts the (optional) *pivot* in-between, and updates [x0, x1] to bracket the pivot. Usually [x0, x1] is the extent of the values, in ascending or descending order.
+
+The default domain is [0, 0.5, 1].
 
 <a name="diverging_clamp" href="#diverging_clamp">#</a> <i>diverging</i>.<b>clamp</b>([<i>clamp</i>]) · [Source](https://github.com/d3/d3-scale/blob/master/src/diverging.js), [Examples](https://observablehq.com/@d3/diverging-scales)
 

--- a/src/diverging.js
+++ b/src/diverging.js
@@ -26,8 +26,18 @@ function transformer() {
     return isNaN(x = +x) ? unknown : (x = 0.5 + ((x = +transform(x)) - t1) * (s * x < s * t1 ? k10 : k21), interpolator(clamp ? Math.max(0, Math.min(1, x)) : x));
   }
 
-  scale.domain = function(_) {
-    return arguments.length ? ([x0, x1, x2] = _, t0 = transform(x0 = +x0), t1 = transform(x1 = +x1), t2 = transform(x2 = +x2), k10 = t0 === t1 ? 0 : 0.5 / (t1 - t0), k21 = t1 === t2 ? 0 : 0.5 / (t2 - t1), s = t1 < t0 ? -1 : 1, scale) : [x0, x1, x2];
+  function domainExtent(extent, pivot) {
+    extent = Array.from(extent);
+    if (extent.length >= 3) return extent;
+    const [x0, x1] = extent;
+    pivot = +pivot || 0;
+    return x1 > x0
+      ? [Math.min(pivot, x0), pivot, Math.max(pivot, x1)]
+      : [Math.max(pivot, x0), pivot, Math.min(pivot, x1)];
+  }
+
+  scale.domain = function(_, __) {
+    return arguments.length ? ([x0, x1, x2] = domainExtent(_, __), t0 = transform(x0 = +x0), t1 = transform(x1 = +x1), t2 = transform(x2 = +x2), k10 = t0 === t1 ? 0 : 0.5 / (t1 - t0), k21 = t1 === t2 ? 0 : 0.5 / (t2 - t1), s = t1 < t0 ? -1 : 1, scale) : [x0, x1, x2];
   };
 
   scale.clamp = function(_) {

--- a/test/diverging-test.js
+++ b/test/diverging-test.js
@@ -57,6 +57,27 @@ tape("diverging.domain() handles a degenerate domain", function(test) {
   test.end();
 });
 
+tape("diverging.domain() handles a two-values domain with a pivot", function(test) {
+  var s = scale.scaleDiverging().domain([2, 3]);
+  test.deepEqual(s.domain(), [0, 0, 3]);
+  s.domain([-2, -1]);
+  test.deepEqual(s.domain(), [-2, 0, 0]);
+  s.domain([-5, 1256], 100);
+  test.deepEqual(s.domain(), [-5, 100, 1256]);
+  test.end();
+});
+
+tape("diverging.domain() handles a two-values descending domain", function(test) {
+  var s = scale.scaleDiverging();
+  s.domain([2, -2]);
+  test.deepEqual(s.domain(), [2, 0, -2]);
+  s.domain([2, -2], 1);
+  test.deepEqual(s.domain(), [2, 1, -2]);
+  s.domain([2, -2], -3);
+  test.deepEqual(s.domain(), [2, -3, -3]);
+  test.end();
+});
+
 tape("diverging.domain() handles a descending domain", function(test) {
   var s = scale.scaleDiverging().domain([4, 2, 1]);
   test.deepEqual(s.domain(), [4, 2, 1]);


### PR DESCRIPTION
examples:
-  d3.scaleDiverging().domain([-10, 145]).domain() // [-10, 0, 145]
-  d3.scaleDiverging().domain([89, 145], 100).domain() // [89, 100, 145]
-  d3.scaleDiverging().domain([112, 145], 100).domain() // [100, 100, 145]
-  d3.scaleDiverging().domain([-112, -145], -100).domain() // [-100, -100, -145]

solves https://github.com/d3/d3-array/issues/132