### PR TITLE
Update: add name to anonymous exported function declarations

### DIFF
--- a/src/colors.js
+++ b/src/colors.js
@@ -1,4 +1,4 @@
-export default function(s) {
+export default function colors(s) {
   return s.match(/.{6}/g).map(function(x) {
     return "#" + x;
   });

--- a/src/constant.js
+++ b/src/constant.js
@@ -1,4 +1,4 @@
-export default function(x) {
+export default function constants(x) {
   return function() {
     return x;
   };

--- a/src/nice.js
+++ b/src/nice.js
@@ -1,4 +1,4 @@
-export default function(domain, interval) {
+export default function nice(domain, interval) {
   domain = domain.slice();
 
   var i0 = 0,

--- a/src/number.js
+++ b/src/number.js
@@ -1,3 +1,3 @@
-export default function(x) {
+export default function number(x) {
   return +x;
 }

--- a/src/tickFormat.js
+++ b/src/tickFormat.js
@@ -1,7 +1,7 @@
 import {tickStep} from "d3-array";
 import {format, formatPrefix, formatSpecifier, precisionFixed, precisionPrefix, precisionRound} from "d3-format";
 
-export default function(start, stop, count, specifier) {
+export default function tickFormat(start, stop, count, specifier) {
   var step = tickStep(start, stop, count),
       precision;
   specifier = formatSpecifier(specifier == null ? ",f" : specifier);

--- a/src/time.js
+++ b/src/time.js
@@ -131,6 +131,6 @@ export function calendar(year, month, week, day, hour, minute, second, milliseco
   return scale;
 }
 
-export default function() {
+export default function time() {
   return initRange.apply(calendar(timeYear, timeMonth, timeWeek, timeDay, timeHour, timeMinute, timeSecond, timeMillisecond, timeFormat).domain([new Date(2000, 0, 1), new Date(2000, 0, 2)]), arguments);
 }

--- a/src/utcTime.js
+++ b/src/utcTime.js
@@ -3,6 +3,6 @@ import {utcFormat} from "d3-time-format";
 import {utcYear, utcMonth, utcWeek, utcDay, utcHour, utcMinute, utcSecond, utcMillisecond} from "d3-time";
 import {initRange} from "./init.js";
 
-export default function() {
+export default function utcTime() {
   return initRange.apply(calendar(utcYear, utcMonth, utcWeek, utcDay, utcHour, utcMinute, utcSecond, utcMillisecond, utcFormat).domain([Date.UTC(2000, 0, 1), Date.UTC(2000, 0, 2)]), arguments);
 }


### PR DESCRIPTION
The Babel rule: no-anonymous-default-export is complaining about the amount of anonymous exports that are in d3-scale.

This will solve this issue.
