### PR TITLE
scaleQuantile performance fixup

### DIFF
--- a/src/quantile.js
+++ b/src/quantile.js
@@ -1,4 +1,4 @@
-import {ascending, bisect, quantile as threshold} from "d3-array";
+import {ascending, bisect, quantileSorted as threshold} from "d3-array";
 import {initRange} from "./init.js";
 
 export default function quantile() {


### PR DESCRIPTION
We've noticed a significant performance drop since upgrading to newer version of `d3-scale`. Based on profiling that we've done it was apparent that `scaleQuantile` was taking much longer to complete for the same input.

By inspecting the code it looks like it's calling out to `d3-array::quantile`, which creates a copy of the array (640k entries in our case) and re-sorts it each time. Since our input is already sorted, and the previous version of this function did not do in-place sorting, using `d3-array::quantileSorted` instead of `d3-array::quantile` gets the performance back to regular execution times.

`d3-array` added `quantileSorted` in [this commit](https://github.com/d3/d3-array/commit/a25e9049e79b6e815a83021ba3d31d77947fdfb5#diff-52a825ef6f76ca7f405e2692c8ce92a5), I assume this update is an expected outcome as it restores the behavior it had prior to this change.