### PR TITLE
docs(scaleIdentity): change parameter name from range to domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,9 +385,9 @@ If *constant* is specified, sets the symlog constant to the specified number and
 
 Identity scales are a special case of [linear scales](#linear-scales) where the domain and range are identical; the scale and its invert method are thus the identity function. These scales are occasionally useful when working with pixel coordinates, say in conjunction with an axis. Identity scales do not support [rangeRound](#continuous_rangeRound), [clamp](#continuous_clamp) or [interpolate](#continuous_interpolate).
 
-<a name="scaleIdentity" href="#scaleIdentity">#</a> d3.<b>scaleIdentity</b>([<i>range</i>]) · [Source](https://github.com/d3/d3-scale/blob/master/src/identity.js), [Examples](https://observablehq.com/@d3/d3-scalelinear)
+<a name="scaleIdentity" href="#scaleIdentity">#</a> d3.<b>scaleIdentity</b>([<i>domain</i>]) · [Source](https://github.com/d3/d3-scale/blob/master/src/identity.js), [Examples](https://observablehq.com/@d3/d3-scalelinear)
 
-Constructs a new identity scale with the specified [domain](#continuous_domain) and [range](#continuous_range). If *range* is not specified, it defaults to [0, 1].
+Constructs a new identity scale with the specified [domain](#continuous_domain) and [range](#continuous_range). If *domain* is not specified, it defaults to [0, 1].
 
 #### Radial Scales
 


### PR DESCRIPTION
In the readme, the parameter of function signature for `scaleIdentity` is called `range`, but in the source code it is called `domain`. I think it's better to unify them, so I change the parameter  from `range` to `domain` in the readme.

<img width="857" alt="截屏2021-03-19 下午5 35 02" src="https://user-images.githubusercontent.com/49330279/111761238-a6588800-88da-11eb-9ad0-019d90429caa.png">
<img width="506" alt="截屏2021-03-19 下午5 43 05" src="https://user-images.githubusercontent.com/49330279/111761244-a8224b80-88da-11eb-9997-bec598e99d52.png">
