### PR TITLE
Add package.json to exports for React Native

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,11 @@
   "jsdelivr": "dist/d3-scale.min.js",
   "unpkg": "dist/d3-scale.min.js",
   "exports": {
-    "umd": "./dist/d3-scale.min.js",
-    "default": "./src/index.js"
+    "./package.json": "./package.json",
+    ".": {
+      "umd": "./dist/d3-scale.min.js",
+      "default": "./src/index.js"
+    }
   },
   "sideEffects": false,
   "dependencies": {


### PR DESCRIPTION
This is required or Metro, React Native's bundler, complains and the build breaks.
You can check [this](https://github.com/react-native-community/cli/issues/1168) for reference.