### PR TITLE
fix: remove build warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,6 @@
   "main": "src/index.js",
   "jsdelivr": "dist/d3-scale.min.js",
   "unpkg": "dist/d3-scale.min.js",
-  "exports": {
-    "umd": "./dist/d3-scale.min.js",
-    "default": "./src/index.js"
-  },
   "sideEffects": false,
   "dependencies": {
     "d3-array": "2.10.0 - 3",


### PR DESCRIPTION
### Package warning


warn Package d3-scale has been ignored because it contains invalid configuration. Reason: Package subpath './package.json' is not defined by "exports" in /node_modules/d3-scale/package.json
