### PR TITLE
Support React Native

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "unpkg": "dist/d3-scale.min.js",
   "exports": {
     "umd": "./dist/d3-scale.min.js",
-    "default": "./src/index.js"
+    "default": "./src/index.js",
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "dependencies": {


### PR DESCRIPTION
@react-native-community/cli (used by expo and I *think* react native), parses package.json to determine package paths.

This is necessary to build react native projects. See https://github.com/react-native-community/cli/issues/1168 for more details.