### PR TITLE
Add type names to scales

### DIFF
--- a/src/band.js
+++ b/src/band.js
@@ -15,6 +15,8 @@ export default function band() {
       paddingOuter = 0,
       align = 0.5;
 
+  scale.type= 'band';
+
   delete scale.unknown;
 
   function rescale() {
@@ -97,5 +99,7 @@ function pointish(scale) {
 }
 
 export function point() {
-  return pointish(band.apply(null, arguments).paddingInner(1));
+  const s = pointish(band.apply(null, arguments).paddingInner(1));
+  s.type = 'point';
+  return s;
 }

--- a/src/diverging.js
+++ b/src/diverging.js
@@ -78,7 +78,9 @@ export function divergingLog() {
     return copy(scale, divergingLog()).base(scale.base());
   };
 
-  return initInterpolator.apply(scale, arguments);
+  const s = initInterpolator.apply(scale, arguments);
+  s.type = 'divergingLog';
+  return s;
 }
 
 export function divergingSymlog() {
@@ -88,7 +90,9 @@ export function divergingSymlog() {
     return copy(scale, divergingSymlog()).constant(scale.constant());
   };
 
-  return initInterpolator.apply(scale, arguments);
+  const s = initInterpolator.apply(scale, arguments);
+  s.type = 'divergingSymlog';
+  return s;
 }
 
 export function divergingPow() {
@@ -98,9 +102,13 @@ export function divergingPow() {
     return copy(scale, divergingPow()).exponent(scale.exponent());
   };
 
-  return initInterpolator.apply(scale, arguments);
+  const s = initInterpolator.apply(scale, arguments);
+  s.type = 'divergingPow';
+  return s;
 }
 
 export function divergingSqrt() {
-  return divergingPow.apply(null, arguments).exponent(0.5);
+  const s = divergingPow.apply(null, arguments).exponent(0.5);
+  s.type = 'divergingSqrt';
+  return s;
 }

--- a/src/diverging.js
+++ b/src/diverging.js
@@ -66,7 +66,9 @@ export default function diverging() {
     return copy(scale, diverging());
   };
 
-  return initInterpolator.apply(scale, arguments);
+  const s = initInterpolator.apply(scale, arguments);
+  s.type = 'diverging';
+  return s;
 }
 
 export function divergingLog() {

--- a/src/identity.js
+++ b/src/identity.js
@@ -24,5 +24,7 @@ export default function identity(domain) {
 
   domain = arguments.length ? Array.from(domain, number) : [0, 1];
 
-  return linearish(scale);
+  const s = linearish(scale);
+  s.type = 'identity';
+  return s;
 }

--- a/src/linear.js
+++ b/src/linear.js
@@ -32,7 +32,7 @@ export function linearish(scale) {
       step = start, start = stop, stop = step;
       step = i0, i0 = i1, i1 = step;
     }
-    
+
     while (maxIter-- > 0) {
       step = tickIncrement(start, stop, count);
       if (step === prestep) {
@@ -66,5 +66,7 @@ export default function linear() {
 
   initRange.apply(scale, arguments);
 
-  return linearish(scale);
+  const s = linearish(scale);
+  s.type = 'linear';
+  return s;
 }

--- a/src/log.js
+++ b/src/log.js
@@ -136,5 +136,6 @@ export default function log() {
   const scale = loggish(transformer()).domain([1, 10]);
   scale.copy = () => copy(scale, log()).base(scale.base());
   initRange.apply(scale, arguments);
+  scale.type= 'log';
   return scale;
 }

--- a/src/ordinal.js
+++ b/src/ordinal.js
@@ -42,5 +42,7 @@ export default function ordinal() {
 
   initRange.apply(scale, arguments);
 
+  scale.type= 'ordinal';
+
   return scale;
 }

--- a/src/pow.js
+++ b/src/pow.js
@@ -42,9 +42,12 @@ export default function pow() {
 
   initRange.apply(scale, arguments);
 
+  scale.type= 'pow';
   return scale;
 }
 
 export function sqrt() {
-  return pow.apply(null, arguments).exponent(0.5);
+  const s = pow.apply(null, arguments).exponent(0.5);
+  s.type = 'sqrt';
+  return s;
 }

--- a/src/quantile.js
+++ b/src/quantile.js
@@ -53,5 +53,7 @@ export default function quantile() {
         .unknown(unknown);
   };
 
-  return initRange.apply(scale, arguments);
+  const s = initRange.apply(scale, arguments);
+  s.type = 'quantile';
+  return s;
 }

--- a/src/quantize.js
+++ b/src/quantize.js
@@ -52,5 +52,7 @@ export default function quantize() {
         .unknown(unknown);
   };
 
-  return initRange.apply(linearish(scale), arguments);
+  const s = initRange.apply(linearish(scale), arguments);
+  s.type = 'quantize';
+  return s;
 }

--- a/src/radial.js
+++ b/src/radial.js
@@ -59,5 +59,7 @@ export default function radial() {
 
   initRange.apply(scale, arguments);
 
-  return linearish(scale);
+  const s = linearish(scale);
+  s.type = 'radial';
+  return s;
 }

--- a/src/sequential.js
+++ b/src/sequential.js
@@ -69,7 +69,9 @@ export default function sequential() {
     return copy(scale, sequential());
   };
 
-  return initInterpolator.apply(scale, arguments);
+  const s = initInterpolator.apply(scale, arguments);
+  s.type = 'sequential';
+  return s;
 }
 
 export function sequentialLog() {
@@ -79,7 +81,9 @@ export function sequentialLog() {
     return copy(scale, sequentialLog()).base(scale.base());
   };
 
-  return initInterpolator.apply(scale, arguments);
+  const s = initInterpolator.apply(scale, arguments);
+  s.type = 'sequentialLog';
+  return s;
 }
 
 export function sequentialSymlog() {
@@ -89,7 +93,9 @@ export function sequentialSymlog() {
     return copy(scale, sequentialSymlog()).constant(scale.constant());
   };
 
-  return initInterpolator.apply(scale, arguments);
+  const s = initInterpolator.apply(scale, arguments);
+  s.type = 'sequentialSymlog';
+  return s;
 }
 
 export function sequentialPow() {
@@ -99,9 +105,13 @@ export function sequentialPow() {
     return copy(scale, sequentialPow()).exponent(scale.exponent());
   };
 
-  return initInterpolator.apply(scale, arguments);
+  const s = initInterpolator.apply(scale, arguments);
+  s.type = 'sequentialPow';
+  return s;
 }
 
 export function sequentialSqrt() {
-  return sequentialPow.apply(null, arguments).exponent(0.5);
+  const s = sequentialPow.apply(null, arguments).exponent(0.5);
+  s.type = 'sequentialSqrt';
+  return s;
 }

--- a/src/sequentialQuantile.js
+++ b/src/sequentialQuantile.js
@@ -34,5 +34,7 @@ export default function sequentialQuantile() {
     return sequentialQuantile(interpolator).domain(domain);
   };
 
-  return initInterpolator.apply(scale, arguments);
+  const s = initInterpolator.apply(scale, arguments);
+  s.type = 'sequentialQuantile';
+  return s;
 }

--- a/src/symlog.js
+++ b/src/symlog.js
@@ -31,5 +31,7 @@ export default function symlog() {
     return copy(scale, symlog()).constant(scale.constant());
   };
 
-  return initRange.apply(scale, arguments);
+  const s = initRange.apply(scale, arguments);
+  s.type = 'symlog';
+  return s;
 }

--- a/src/threshold.js
+++ b/src/threshold.js
@@ -35,5 +35,7 @@ export default function threshold() {
         .unknown(unknown);
   };
 
-  return initRange.apply(scale, arguments);
+  const s = initRange.apply(scale, arguments);
+  s.type = 'threshold';
+  return s;
 }

--- a/src/time.js
+++ b/src/time.js
@@ -67,5 +67,7 @@ export function calendar(ticks, tickInterval, year, month, week, day, hour, minu
 }
 
 export default function time() {
-  return initRange.apply(calendar(timeTicks, timeTickInterval, timeYear, timeMonth, timeWeek, timeDay, timeHour, timeMinute, timeSecond, timeFormat).domain([new Date(2000, 0, 1), new Date(2000, 0, 2)]), arguments);
+  const s = initRange.apply(calendar(timeTicks, timeTickInterval, timeYear, timeMonth, timeWeek, timeDay, timeHour, timeMinute, timeSecond, timeFormat).domain([new Date(2000, 0, 1), new Date(2000, 0, 2)]), arguments);
+  s.type = 'time';
+  return s;
 }

--- a/src/utcTime.js
+++ b/src/utcTime.js
@@ -4,5 +4,7 @@ import {calendar} from "./time.js";
 import {initRange} from "./init.js";
 
 export default function utcTime() {
-  return initRange.apply(calendar(utcTicks, utcTickInterval, utcYear, utcMonth, utcWeek, utcDay, utcHour, utcMinute, utcSecond, utcFormat).domain([Date.UTC(2000, 0, 1), Date.UTC(2000, 0, 2)]), arguments);
+  const s = initRange.apply(calendar(utcTicks, utcTickInterval, utcYear, utcMonth, utcWeek, utcDay, utcHour, utcMinute, utcSecond, utcFormat).domain([Date.UTC(2000, 0, 1), Date.UTC(2000, 0, 2)]), arguments);
+  s.type = 'utc';
+  return s;
 }

--- a/test/band-test.js
+++ b/test/band-test.js
@@ -11,6 +11,7 @@ it("scaleBand() has the expected defaults", () => {
   assert.strictEqual(s.paddingInner(), 0);
   assert.strictEqual(s.paddingOuter(), 0);
   assert.strictEqual(s.align(), 0.5);
+  assert.strictEqual(s.type, 'band');
 });
 
 it("band(value) computes discrete bands in a continuous range", () => {

--- a/test/diverging-test.js
+++ b/test/diverging-test.js
@@ -11,6 +11,7 @@ it("scaleDiverging() has the expected defaults", () => {
   assert.strictEqual(s( 0.5),  0.5);
   assert.strictEqual(s( 1.0),  1.0);
   assert.strictEqual(s( 1.5),  1.5);
+  assert.strictEqual(s.type, 'diverging');
 });
 
 it("diverging.clamp(true) enables clamping", () => {

--- a/test/identity-test.js
+++ b/test/identity-test.js
@@ -5,6 +5,7 @@ it("scaleIdentity() has the expected defaults", () => {
   const s = scaleIdentity();
   assert.deepStrictEqual(s.domain(), [0, 1]);
   assert.deepStrictEqual(s.range(), [0, 1]);
+  assert.strictEqual(s.type, 'identity');
 });
 
 it("scaleIdentity(range) sets the domain and range", () => {

--- a/test/linear-test.js
+++ b/test/linear-test.js
@@ -9,6 +9,7 @@ it("scaleLinear() has the expected defaults", () => {
   assert.strictEqual(s.clamp(), false);
   assert.strictEqual(s.unknown(), undefined);
   assert.deepStrictEqual(s.interpolate()({array: ["red"]}, {array: ["blue"]})(0.5), {array: ["rgb(128, 0, 128)"]});
+  assert.strictEqual(s.type, 'linear');
 });
 
 it("scaleLinear(range) sets the range", () => {

--- a/test/log-test.js
+++ b/test/log-test.js
@@ -17,6 +17,7 @@ it("scaleLog() has the expected defaults", () => {
   assertInDelta(x.invert(0.69897), 5);
   assertInDelta(x(3.162278), 0.5);
   assertInDelta(x.invert(0.5), 3.162278);
+  assert.strictEqual(x.type, 'log');
 });
 
 it("log.domain(…) coerces values to numbers", () => {

--- a/test/ordinal-test.js
+++ b/test/ordinal-test.js
@@ -8,6 +8,7 @@ it("scaleOrdinal() has the expected defaults", () => {
   assert.strictEqual(s(0), undefined);
   assert.strictEqual(s.unknown(), scaleImplicit);
   assert.deepStrictEqual(s.domain(), [0]);
+  assert.strictEqual(s.type, 'ordinal');
 });
 
 it("ordinal(x) maps a unique name x in the domain to the corresponding value y in the range", () => {

--- a/test/point-test.js
+++ b/test/point-test.js
@@ -10,6 +10,7 @@ it("scalePoint() has the expected defaults", () => {
   assert.strictEqual(s.round(), false);
   assert.strictEqual(s.padding(), 0);
   assert.strictEqual(s.align(), 0.5);
+  assert.strictEqual(s.type, 'point');
 });
 
 it("scalePoint() does not expose paddingInner and paddingOuter", () => {

--- a/test/pow-test.js
+++ b/test/pow-test.js
@@ -10,6 +10,7 @@ it("scalePow() has the expected defaults", () => {
   assert.strictEqual(s.clamp(), false);
   assert.strictEqual(s.exponent(), 1);
   assert.deepStrictEqual(s.interpolate()({array: ["red"]}, {array: ["blue"]})(0.5), {array: ["rgb(128, 0, 128)"]});
+  assert.strictEqual(s.type, 'pow');
 });
 
 it("pow(x) maps a domain value x to a range value y", () => {

--- a/test/quantile-test.js
+++ b/test/quantile-test.js
@@ -6,6 +6,7 @@ it("scaleQuantile() has the expected default", () => {
   assert.deepStrictEqual(s.domain(), []);
   assert.deepStrictEqual(s.range(), []);
   assert.strictEqual(s.unknown(), undefined);
+  assert.strictEqual(s.type, 'quantile');
 });
 
 it("quantile(x) uses the R-7 algorithm to compute quantiles", () => {

--- a/test/quantize-test.js
+++ b/test/quantize-test.js
@@ -10,6 +10,7 @@ it("scaleQuantize() has the expected defaults", () => {
   assert.deepStrictEqual(s.thresholds(), [0.5]);
   assert.strictEqual(s(0.25), 0);
   assert.strictEqual(s(0.75), 1);
+  assert.strictEqual(s.type, 'quantize');
 });
 
 it("quantize(value) maps a number to a discrete value in the range", () => {

--- a/test/radial-test.js
+++ b/test/radial-test.js
@@ -7,6 +7,7 @@ it("scaleRadial() has the expected defaults", () => {
   assert.deepStrictEqual(s.range(), [0, 1]);
   assert.strictEqual(s.clamp(), false);
   assert.strictEqual(s.round(), false);
+  assert.strictEqual(s.type, 'radial');
 });
 
 it("scaleRadial(range) sets the range", () => {

--- a/test/sequential-test.js
+++ b/test/sequential-test.js
@@ -12,6 +12,7 @@ it("scaleSequential() has the expected defaults", () => {
   assert.strictEqual(s( 0.5),  0.5);
   assert.strictEqual(s( 1.0),  1.0);
   assert.strictEqual(s( 1.5),  1.5);
+  assert.strictEqual(s.type, 'sequential');
 });
 
 it("sequential.clamp(true) enables clamping", () => {

--- a/test/sequentialQuantile-test.js
+++ b/test/sequentialQuantile-test.js
@@ -8,6 +8,7 @@ it("sequentialQuantile() clamps", () => {
   assert.strictEqual(s(1), 0.25);
   assert.strictEqual(s(10), 1);
   assert.strictEqual(s(20), 1);
+  assert.strictEqual(s.type, 'sequentialQuantile');
 });
 
 it("sequentialQuantile().domain() sorts the domain", () => {

--- a/test/sqrt-test.js
+++ b/test/sqrt-test.js
@@ -8,6 +8,7 @@ it("scaleSqrt() has the expected defaults", () => {
   assert.strictEqual(s.clamp(), false);
   assert.strictEqual(s.exponent(), 0.5);
   assert.deepStrictEqual(s.interpolate()({array: ["red"]}, {array: ["blue"]})(0.5), {array: ["rgb(128, 0, 128)"]});
+  assert.strictEqual(s.type, 'sqrt');
 });
 
 it("sqrt(x) maps a domain value x to a range value y", () => {

--- a/test/symlog-test.js
+++ b/test/symlog-test.js
@@ -8,6 +8,7 @@ it("scaleSymlog() has the expected defaults", () => {
   assert.deepStrictEqual(s.range(), [0, 1]);
   assert.strictEqual(s.clamp(), false);
   assert.strictEqual(s.constant(), 1);
+  assert.strictEqual(s.type, 'symlog');
 });
 
 it("symlog(x) maps a domain value x to a range value y", () => {

--- a/test/threshold-test.js
+++ b/test/threshold-test.js
@@ -7,6 +7,7 @@ it("scaleThreshold() has the expected defaults", () => {
   assert.deepStrictEqual(x.range(), [0, 1]);
   assert.strictEqual(x(0.50), 1);
   assert.strictEqual(x(0.49), 0);
+  assert.strictEqual(x.type, 'threshold');
 });
 
 it("threshold(x) maps a number to a discrete value in the range", () => {

--- a/test/time-test.js
+++ b/test/time-test.js
@@ -9,6 +9,7 @@ it("time.domain([-1e50, 1e50]) is equivalent to time.domain([NaN, NaN])", () => 
   assert.strictEqual(isNaN(x.domain()[0]), true); // Note: also coerced on retrieval, so insufficient test!
   assert.strictEqual(isNaN(x.domain()[1]), true);
   assert.deepStrictEqual(x.ticks(10), []);
+  assert.strictEqual(x.type, 'time');
 });
 
 it("time.domain(domain) accepts an iterable", () => {

--- a/test/types-test.js
+++ b/test/types-test.js
@@ -1,0 +1,19 @@
+import assert from "assert";
+import * as d3 from "../src/index.js";
+
+const exclude = [
+	'tickFormat',
+	'scaleImplicit'
+]
+
+// test that every scale has the right `type` prop
+Object.keys(d3).filter(d => {
+	return !exclude.includes(d);
+}).forEach(d => {
+	it(`${d}() has the expected type`, () => {
+		const type = d.replace('scale', '')
+			.replace(/^\w/, w => w.toLowerCase())
+		const scale = d3[d]();
+		assert.strictEqual(scale.type, type);
+	});
+});

--- a/test/utcTime-test.js
+++ b/test/utcTime-test.js
@@ -7,6 +7,7 @@ import {utc} from "./date.js";
 it("scaleUtc.nice() is an alias for scaleUtc.nice(10)", () => {
   const x = scaleUtc().domain([utc(2009, 0, 1, 0, 17), utc(2009, 0, 1, 23, 42)]);
   assert.deepStrictEqual(x.nice().domain(), [utc(2009, 0, 1), utc(2009, 0, 2)]);
+  assert.strictEqual(x.type, 'utc');
 });
 
 it("scaleUtc.nice() can nice sub-second domains", () => {


### PR DESCRIPTION
Per https://github.com/d3/d3-scale/issues/25#issuecomment-1426350113, this proposal adds a `type` field to each scale that returns a string name. I called it `type` for now but have no opinion on what that would end up being. Maybe `scaleType` or something else is better. 

I added tests but, for now, only where the existing defaults were being tested. For example, I didn't immediately see where scales like `sequentialLog` were being tested for defaults. I can add those tests where most appropriate. 

Let me know if you think this is a worthwhile addition. It would definitely help my use case with a minimal footprint on the original library. Thanks for your time in reviewing it.